### PR TITLE
coredump: change kernel core pattern to capture cores from containers

### DIFF
--- a/49-coredump.conf
+++ b/49-coredump.conf
@@ -4,4 +4,4 @@
 # and systemd-coredump(8) and core(5) for the explanation of the
 # setting below.
 
-kernel.core_pattern = |/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e
+kernel.core_pattern = |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %e


### PR DESCRIPTION
In RHBZ#1554321, the kernel core pattern was changed to use `%P` in
order to capture core dumps generated by containers.  I think this
makes sense to use the same for RHCOS.