### PR TITLE
Install a ConditionFirstBoot service for /root/.bashrc

### DIFF
--- a/42-coreos.preset
+++ b/42-coreos.preset
@@ -6,3 +6,6 @@
 # Note at some point we'd like to disable docker
 enable docker.service
 enable docker-storage-setup.service
+
+# Work around https://bugzilla.redhat.com/show_bug.cgi?id=1193590
+enable coreos-root-bash-profile-workaround.service

--- a/coreos-root-bash-profile-workaround.service
+++ b/coreos-root-bash-profile-workaround.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Seed default bash profile for root
+Documentation=https://bugzilla.redhat.com/show_bug.cgi?id=1193590
+DefaultDependencies=no
+Before=sshd.service
+Before=systemd-user-sessions.service
+After=systemd-remount-fs.service
+ConditionFirstBoot=yes
+RequiresMountsFor=/var/roothome
+
+[Service]
+ExecStart=/bin/sh -c 'cp /etc/skel/.bash* /var/roothome'
+
+[Install]
+WantedBy=multi-user.target

--- a/redhat-release-coreos.spec
+++ b/redhat-release-coreos.spec
@@ -116,6 +116,10 @@ install -m 644 GPL %{buildroot}/%{_docdir}/redhat-release
 mkdir -p %{buildroot}/%{_prefix}/lib/systemd/system-preset/
 for x in *.preset; do install -m 0644 ${x} %{buildroot}/%{_prefix}/lib/systemd/system-preset/; done
 
+# copy systemd units
+mkdir -p %{buildroot}/%{_prefix}/lib/systemd/system/
+for x in *.service; do install -m 0644 ${x} %{buildroot}/%{_prefix}/lib/systemd/system/; done
+
 # let systemd handle core dumps
 # https://bugzilla.redhat.com/show_bug.cgi?id=1191045
 mkdir -p %{buildroot}%{_prefix}/lib/sysctl.d/
@@ -145,5 +149,6 @@ rm -rf %{buildroot}
 /etc/rpm/macros.dist
 %{_docdir}/redhat-release/*
 %{_datadir}/redhat-release/*
+%{_prefix}/lib/systemd/system/*.service
 %{_prefix}/lib/systemd/system-preset/*
 %{_prefix}/lib/sysctl.d/*


### PR DESCRIPTION
This is cleaner than doing it in the `cloud.ks`; it works for bare
metal too.  If you do a full factory reset it comes back, etc.

The reason I'm doing this now specifically is that I want to be
able to make a change to `/etc/skel` and have that consistently
reflected for root too.