### PR TITLE
Tweak release versions

### DIFF
--- a/redhat-release-coreos.spec
+++ b/redhat-release-coreos.spec
@@ -7,9 +7,9 @@
 %define variant_titlecase CoreOS
 %define variant_lowercase coreos
 %define release_pkg_version 20180515.0
-%define base_release_version 3
-%define full_release_version 3.10
-%define dist_release_version 3
+%define base_release_version 7
+%define full_release_version 4.0
+%define dist_release_version 7
 # Fake this out; we need at least 7, since e.g. systemd has a dependency
 # on system-release > 7.2, etc.
 %define os_version 7.99


### PR DESCRIPTION
- Set `base_release_version` and `dist_release_version` to 7 because
  things like `el4` and `4Server` and `%rhel 4` don't make any sense.
- But set `full_release_version` to `4.0` -- i.e. the actual version of
  the OS. This makes it into the more user-visible places like
  `os-release` and `redhat-release`.

The latter is also required to make the changes in
https://github.com/openshift/os/pull/214 work since `mutate-os-release`
should be a string that matches the baked value we ship here so that
rpm-ostree knows how to modify it.