### PR TITLE
*.service: Use RemainAfterExit=yes

### DIFF
--- a/coreos-root-bash-profile-workaround.service
+++ b/coreos-root-bash-profile-workaround.service
@@ -10,6 +10,7 @@ RequiresMountsFor=/var/roothome
 
 [Service]
 ExecStart=/bin/sh -c 'cp /etc/skel/.bash* /var/roothome'
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
See https://github.com/ostreedev/ostree/pull/1697

Just noticed this while investigating our services after the
recent machine-id regression.