### PR TITLE
preset: Enable pivot.service

### DIFF
--- a/42-coreos.preset
+++ b/42-coreos.preset
@@ -16,3 +16,7 @@ enable coreos-firstboot-complete.service
 
 # Displays boot status https://github.com/projectatomic/rpm-ostree/pull/1693
 enable rpm-ostree-bootstatus.service
+
+# Enable the pivot service to allow pivoting on first boot
+# See https://github.com/openshift/pivot/pull/25.
+enable pivot.service


### PR DESCRIPTION
This gives RHCOS the capability to pivot right on first boot. We aren't
using this right now (though we were close to) since the MCD just
directly starts the service as needed. But I think it'd be nice for
RHCOS to support this OOTB.