### PR TITLE
ootpa: fix dist

### DIFF
--- a/redhat-release-coreos.spec
+++ b/redhat-release-coreos.spec
@@ -9,7 +9,7 @@
 %define base_version 8
 # Fake this out; we also use 8 here, matching the maipo's use of 7.
 %define os_version 8.99
-%define dist .el%{version}
+%define dist .el%{base_version}
 
 Name:           redhat-release-coreos
 Version:        48


### PR DESCRIPTION
Fix dist var to base_version, otherwise the suffix will look like
'el48' instead of 'el8'.