### PR TITLE
Create and own /etc/issue.d

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,12 +31,13 @@ ln -s ../usr/lib/os-release etc/os-release
 # Sadly grub2 still reads this
 ln -s ../usr/lib/os-release etc/system-release
 
-# create /etc/issue and /etc/issue.net
+# create /etc/issue, /etc/issue.net, and /etc/issue.d
 cat > usr/lib/issue <<'EOF'
 \S \S{VERSION_ID}
 EOF
 ln -sr usr/lib/issue etc/issue
 ln -sr usr/lib/issue etc/issue.net
+mkdir -p -m 755 etc/issue.d
 
 # combine GPG keys
 mkdir -p -m 755 etc/pki/rpm-gpg

--- a/redhat-release-coreos.spec
+++ b/redhat-release-coreos.spec
@@ -40,3 +40,4 @@ cp -a --reflink=auto fs %{buildroot}
 (cd %{buildroot} && find . -type f -o -type l | sed -e 's,^.,/,') > files.list
 
 %files -f files.list
+%dir /etc/issue.d


### PR DESCRIPTION
Bring the changes from #18 into the ootpa version.

I had originally meant for this to go into ootpa only, and should have opened against the ootpa branch. Will open a PR to revert #18, as the change is not needed in maipo.

Tested by installing an RPM with this change into an ootpa RHCOS image - ownership by `redhat-release-coreos` is applied correctly to `/etc/issue.d`.